### PR TITLE
Implement atomic wrapper for complex64

### DIFF
--- a/complex64.go
+++ b/complex64.go
@@ -5,13 +5,13 @@ import (
 	"sync/atomic"
 )
 
-// Float32 is an atomic wrapper around float32.
+// Complex64 is an atomic wrapper around float32.
 type Complex64 struct {
 	r uint32
 	i uint32
 }
 
-// NewFloat32 creates a float32.
+// NewComplex65 creates a float32.
 func NewComplex64(f complex64) *Complex64 {
 	return &Complex64{
 		math.Float32bits(real(f)),

--- a/complex64.go
+++ b/complex64.go
@@ -1,0 +1,54 @@
+package atomix
+
+import (
+	"math"
+	"sync/atomic"
+)
+
+// Float32 is an atomic wrapper around float32.
+type Complex64 struct {
+	r uint32
+	i uint32
+}
+
+// NewFloat32 creates a float32.
+func NewComplex64(f complex64) *Complex64 {
+	return &Complex64{
+		math.Float32bits(real(f)),
+		math.Float32bits(imag(f)),
+	}
+}
+
+// Load atomically the value.
+func (f *Complex64) Load() complex64 {
+	return complex(math.Float32frombits(atomic.LoadUint32(&f.r)), math.Float32frombits(atomic.LoadUint32(&f.i)))
+}
+
+// Store atomically the passed value.
+func (f *Complex64) Store(s complex64) {
+	atomic.StoreUint32(&f.r, math.Float32bits(real(s)))
+	atomic.StoreUint32(&f.i, math.Float32bits(imag(s)))
+}
+
+// Add atomically and return the new value.
+func (f *Complex64) Add(s complex64) complex64 {
+	for {
+		old := f.Load()
+		new := old + s
+		if f.CAS(old, new) {
+			return new
+		}
+	}
+}
+
+// Sub atomically and return the new value.
+func (f *Complex64) Sub(s complex64) complex64 {
+	return f.Add(-s)
+}
+
+// CAS is an atomic Compare-and-swap.
+func (f *Complex64) CAS(old, new complex64) bool {
+	r := atomic.CompareAndSwapUint32(&f.r, math.Float32bits(real(old)), math.Float32bits(real(new)))
+	i := atomic.CompareAndSwapUint32(&f.i, math.Float32bits(imag(old)), math.Float32bits(imag(new)))
+	return r && i
+}

--- a/complex64_test.go
+++ b/complex64_test.go
@@ -1,0 +1,29 @@
+package atomix
+
+import (
+	"testing"
+)
+
+func TestComplex64(t *testing.T) {
+	a := NewComplex64(complex(10.5, 10.5))
+	var c complex64 = complex(10.5, 10.5)
+
+	Equal(t, c, a.Load(), "Load wrong value")
+
+	var c1 complex64 = complex(10.8, 10.8)
+	var c2 complex64 = complex(10.3, 10.3)
+	var c3 complex64 = complex(0.5, 0.5)
+	var c4 complex64 = complex(0, 0)
+	var c5 complex64 = complex(1.5, 1.5)
+
+	Equal(t, c1, a.Add(complex(0.3, 0.3)), "Add wrong value")
+	Equal(t, c2, a.Sub(complex(0.5, 0.5)), "Sub wrong value")
+
+	OK(t, a.CAS(c2, complex(0.5, 0.5)), "CAS should swap")
+	Equal(t, c3, a.Load(), "CAS wrong value")
+	NotOK(t, a.CAS(c4, c5), "CAS shouldn't swap")
+
+	a.Store(complex(42.0, 47.0))
+	var d complex64 = complex(42.0, 47.0)
+	Equal(t, d, a.Load(), "Store wrong value")
+}


### PR DESCRIPTION
I'm looking to contribute on issues regarding Golang's atomic package, and this seemed an easy start. 

Let me know how this looks. In case we can merge this I could do the same for `complex128` as well.

Fixes : https://github.com/cristalhq/atomix/issues/2